### PR TITLE
Feature/31 - photo repository

### DIFF
--- a/src/main/java/pro/sky/animalsheltertelegrambot/controller/PhotoController.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/controller/PhotoController.java
@@ -1,6 +1,7 @@
 package pro.sky.animalsheltertelegrambot.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -16,7 +17,7 @@ import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Фотографии", description = "Возможные операции с фотографиями")
+@Tag(name = "Фотографии", description = "Возможные операции с фотографиями, могут относиться либо к питомцу, либо к отчету")
 @RequestMapping("/photos")
 public class PhotoController {
     private final PhotoService photoService;
@@ -24,8 +25,7 @@ public class PhotoController {
     @Operation(
             summary = "Добавление фотографий питомца в базу",
             responses = {
-                    @ApiResponse(
-                            responseCode = "201",
+                    @ApiResponse(responseCode = "201",
                             description = "Успешное добавление фотографий"
                     ),
                     @ApiResponse(
@@ -35,9 +35,9 @@ public class PhotoController {
             }
     )
     @PostMapping(value = "for-pet/{petId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> addPhotosForPet(@PathVariable Long petId, @RequestBody MultipartFile[] photos) throws IOException {
+    public void addPhotosForPet(@Parameter(description = "ID питомца") @PathVariable Long petId,
+                                @Parameter(description = "Загружаемые фотографии") @RequestBody MultipartFile[] photos) throws IOException {
         photoService.addPhotosForPet(petId, photos);
-        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @Operation(
@@ -54,53 +54,53 @@ public class PhotoController {
             }
     )
     @PostMapping(value = "for-report/{reportId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> addPhotosForReport(@PathVariable Long reportId, @RequestParam MultipartFile[] photos) throws IOException {
+    public void addPhotosForReport(@Parameter(description = "ID отчета") @PathVariable Long reportId,
+                                   @Parameter(description = "Загружаемые фотографии") @RequestParam MultipartFile[] photos) throws IOException {
         photoService.addPhotosForReport(reportId, photos);
-        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @Operation(
-            summary = "Получение фотографии по ID",
+            summary = "Получение фотографий по ID питомца",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "Фотография найдена"
+                            description = "Фотографии найдены"
                     ),
                     @ApiResponse(
                             responseCode = "400",
-                            description = "Фотография не найдена"
+                            description = "Фотографии не найдены"
                     )
             }
     )
-    @GetMapping("/for-pet/{petId}")
-    public ResponseEntity<?> getPhotosForPet(@PathVariable Long petId,
-                                             HttpServletResponse response) {
-        photoService.getPhotosByPetId(petId, response);
-        return new ResponseEntity<>(HttpStatus.OK);
+    @GetMapping(value = "/for-pet/{petId}/{photoNumber}")
+    public void getPhotosForPet(@Parameter(description = "ID питомца") @PathVariable Long petId,
+                                @Parameter(description = "порядковый номер фотографии") @PathVariable Long photoNumber,
+                                HttpServletResponse response) throws IOException {
+        photoService.getPhotosByPetId(petId, photoNumber, response);
     }
 
     @Operation(
-            summary = "Получение фотографии по ID",
+            summary = "Получение фотографий по ID приюта",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "Фотография найдена"
+                            description = "Фотографии найдены"
                     ),
                     @ApiResponse(
                             responseCode = "400",
-                            description = "Фотография не найдена"
+                            description = "Фотографии не найдены"
                     )
             }
     )
-    @GetMapping("/for-report/{reportId}")
-    public ResponseEntity<?> getPhotosForReport(@PathVariable Long reportId,
-                                                HttpServletResponse response) {
-        photoService.getPhotosByReportId(reportId, response);
-        return new ResponseEntity<>(HttpStatus.OK);
+    @GetMapping("/for-report/{reportId}/{photoNumber}")
+    public void getPhotosForReport(@Parameter(description = "ID отчета") @PathVariable Long reportId,
+                                   @Parameter(description = "порядковый номер фотографии") @PathVariable Long photoNumber,
+                                   HttpServletResponse response) throws IOException {
+        photoService.getPhotosByReportId(reportId, photoNumber, response);
     }
 
     @Operation(
-            summary = "Удаление всех фотографий по Id приюта",
+            summary = "Удаление всех фотографий по ID приюта",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -108,18 +108,18 @@ public class PhotoController {
                     ),
                     @ApiResponse(
                             responseCode = "400",
-                            description = "Фотография не найдена"
+                            description = "У питомца еще нет добавленных фотографий"
                     )
             }
     )
     @DeleteMapping("/for-pet/{petId}")
-    public ResponseEntity<String> deleteAllPhotosByPetId(@PathVariable Long petId) {
+    public ResponseEntity<String> deleteAllPhotosByPetId(@Parameter(description = "ID питомца") @PathVariable Long petId) {
         photoService.deletePhotosByPetId(petId);
         return new ResponseEntity<>("All photos deleted for petId: " + petId, HttpStatus.OK);
     }
 
     @Operation(
-            summary = "Удаление всех фотографий по Id отчета",
+            summary = "Удаление всех фотографий по ID отчета",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -127,12 +127,12 @@ public class PhotoController {
                     ),
                     @ApiResponse(
                             responseCode = "400",
-                            description = "У отчета еще нет фотографий"
+                            description = "У отчета еще нет добавленных фотографий"
                     )
             }
     )
     @DeleteMapping("/for-report/{reportId}")
-    public ResponseEntity<String> deleteAllPhotosByReportId(@PathVariable Long reportId) {
+    public ResponseEntity<String> deleteAllPhotosByReportId(@Parameter(description = "ID отчета") @PathVariable Long reportId) {
         photoService.deletePhotosByReportId(reportId);
         return new ResponseEntity<>("All photos deleted for reportId: " + reportId, HttpStatus.OK);
     }

--- a/src/main/java/pro/sky/animalsheltertelegrambot/exception/photos/BadPhotoExtensionException.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/exception/photos/BadPhotoExtensionException.java
@@ -1,0 +1,9 @@
+package pro.sky.animalsheltertelegrambot.exception.photos;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST,
+                reason = "Extension of chosen file is now allowed")
+public class BadPhotoExtensionException extends RuntimeException {
+}

--- a/src/main/java/pro/sky/animalsheltertelegrambot/exception/photos/LimitOfPhotosException.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/exception/photos/LimitOfPhotosException.java
@@ -1,0 +1,9 @@
+package pro.sky.animalsheltertelegrambot.exception.photos;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST,
+                reason = "You are at a quantity limit of photos, max = 9.")
+public class LimitOfPhotosException extends RuntimeException {
+}

--- a/src/main/java/pro/sky/animalsheltertelegrambot/exception/photos/PhotoIsEmptyException.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/exception/photos/PhotoIsEmptyException.java
@@ -1,0 +1,9 @@
+package pro.sky.animalsheltertelegrambot.exception.photos;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST,
+                reason = "For this operation you need to upload files in all lines")
+public class PhotoIsEmptyException extends RuntimeException {
+}

--- a/src/main/java/pro/sky/animalsheltertelegrambot/exception/photos/PhotoNotFoundException.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/exception/photos/PhotoNotFoundException.java
@@ -1,0 +1,9 @@
+package pro.sky.animalsheltertelegrambot.exception.photos;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND,
+        reason = "Photos are not found")
+public class PhotoNotFoundException extends RuntimeException {
+}

--- a/src/main/java/pro/sky/animalsheltertelegrambot/model/Photo.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/model/Photo.java
@@ -4,40 +4,61 @@ package pro.sky.animalsheltertelegrambot.model;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.util.Objects;
 
+/**
+ * Сущность Photo, в соответствующей таблице хранятся фотографии, относящиеся как к питомцам, так и к отчетам.
+ * В случае, если сохраняется фотография питомца, которая не относится ни к какому отчету, то в поле report_id записывается null.
+ */
+@Entity
 @Data
 @AllArgsConstructor
-@Entity
 @NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Table(name = "photos")
 public class Photo {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
-    @Column(name = "report_id")
-    private Long reportId;
 
-    @Column(name = "is_initial")
-    private boolean isInitial;
-
-    @Column(name = "file_path")
+    /**
+     * Путь к файлу, куда сохранилась копия отправленной пользователем фотографии
+     */
     private String filePath;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Photo a = (Photo) o;
-        return Objects.equals(id, a.id);
-    }
+    /**
+     * Размер фотографии
+     */
+    private long fileSize;
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
-    }
+    /**
+     * Поле, хранящее тип файла и расширение
+     */
+    private String mediaType;
+
+    private boolean isInitial;
+
+    /**
+     * ID питомца, фотографии которого была передана
+     * @see Pet
+     */
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "pet_id")
+    private Pet pet;
+
+    /**
+     * ID отчета, к которому была прикреплена фотография питомца.
+     * <p>
+     * Может быть null.
+     * @see Report
+     */
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "report_id")
+    private Report report;
 }

--- a/src/main/java/pro/sky/animalsheltertelegrambot/model/Photo.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/model/Photo.java
@@ -7,8 +7,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import java.util.Objects;
-
 /**
  * Сущность Photo, в соответствующей таблице хранятся фотографии, относящиеся как к питомцам, так и к отчетам.
  * В случае, если сохраняется фотография питомца, которая не относится ни к какому отчету, то в поле report_id записывается null.

--- a/src/main/java/pro/sky/animalsheltertelegrambot/model/Photo.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/model/Photo.java
@@ -35,7 +35,7 @@ public class Photo {
     /**
      * Размер фотографии
      */
-    private long fileSize;
+    private Long fileSize;
 
     /**
      * Поле, хранящее тип файла и расширение

--- a/src/main/java/pro/sky/animalsheltertelegrambot/model/Report.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/model/Report.java
@@ -39,5 +39,7 @@ public class Report {
      * Внешний ключ: ID питомца, к которому относится данный отчет
      * @see Pet
      */
-    private Long petId;
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "pet_id")
+    private Pet petId;
 }

--- a/src/main/java/pro/sky/animalsheltertelegrambot/repository/PhotoRepository.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/repository/PhotoRepository.java
@@ -1,0 +1,21 @@
+package pro.sky.animalsheltertelegrambot.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import pro.sky.animalsheltertelegrambot.model.Photo;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+    @Query(value = "SELECT file_path FROM photos WHERE pet_id = :petId ORDER BY file_path DESC LIMIT 1", nativeQuery = true)
+    Optional<String> findLastFilePathByPetId(@Param("petId") Long petId);
+
+    @Query(value = "SELECT file_path FROM photos WHERE report_id = :reportId ORDER BY file_path DESC LIMIT 1", nativeQuery = true)
+    Optional<String> findLastFilePathByReportId(Long reportId);
+
+    List<Photo> findByPetId(Long petId);
+
+    List<Photo> findByReportId(Long reportId);
+}

--- a/src/main/java/pro/sky/animalsheltertelegrambot/repository/PhotoRepository.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/repository/PhotoRepository.java
@@ -13,7 +13,7 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     Optional<String> findLastFilePathByPetId(@Param("petId") Long petId);
 
     @Query(value = "SELECT file_path FROM photos WHERE report_id = :reportId ORDER BY file_path DESC LIMIT 1", nativeQuery = true)
-    Optional<String> findLastFilePathByReportId(Long reportId);
+    Optional<String> findLastFilePathByReportId(@Param("reportId") Long reportId);
 
     List<Photo> findByPetId(Long petId);
 

--- a/src/main/java/pro/sky/animalsheltertelegrambot/service/PhotoService.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/service/PhotoService.java
@@ -11,9 +11,9 @@ public interface PhotoService {
 
     void addPhotosForReport(Long reportId, MultipartFile[] photos) throws IOException;
 
-    void getPhotosByPetId(Long petId, HttpServletResponse response);
+    void getPhotosByPetId(Long petId, Long photoId, HttpServletResponse response) throws IOException;
 
-    void getPhotosByReportId(Long reportId, HttpServletResponse response);
+    void getPhotosByReportId(Long reportId, Long photoId, HttpServletResponse response) throws IOException;
 
     void deletePhotosByPetId(Long petId);
 

--- a/src/main/java/pro/sky/animalsheltertelegrambot/service/PhotoService.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/service/PhotoService.java
@@ -1,15 +1,21 @@
 package pro.sky.animalsheltertelegrambot.service;
 
-import pro.sky.animalsheltertelegrambot.model.Adoption;
-import pro.sky.animalsheltertelegrambot.model.Photo;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 public interface PhotoService {
 
-    Photo addPhoto(Photo photo);
+    void addPhotosForPet(Long petId, MultipartFile[] photos) throws IOException;
 
-    Photo getPhoto(Long id);
+    void addPhotosForReport(Long reportId, MultipartFile[] photos) throws IOException;
 
-    Photo updatePhoto(Long id, Photo photo);
+    void getPhotosByPetId(Long petId, HttpServletResponse response);
 
-    void deletePhoto(Long id);
+    void getPhotosByReportId(Long reportId, HttpServletResponse response);
+
+    void deletePhotosByPetId(Long petId);
+
+    void deletePhotosByReportId(Long reportId);
 }

--- a/src/main/java/pro/sky/animalsheltertelegrambot/service/impl/PhotoServiceImpl.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/service/impl/PhotoServiceImpl.java
@@ -1,34 +1,251 @@
 package pro.sky.animalsheltertelegrambot.service.impl;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import pro.sky.animalsheltertelegrambot.model.Adoption;
+import org.springframework.web.multipart.MultipartFile;
+import pro.sky.animalsheltertelegrambot.exception.photos.BadPhotoExtensionException;
+import pro.sky.animalsheltertelegrambot.exception.photos.LimitOfPhotosException;
+import pro.sky.animalsheltertelegrambot.exception.photos.PhotoIsEmptyException;
+import pro.sky.animalsheltertelegrambot.exception.photos.PhotoNotFoundException;
+import pro.sky.animalsheltertelegrambot.model.Pet;
 import pro.sky.animalsheltertelegrambot.model.Photo;
+import pro.sky.animalsheltertelegrambot.model.Report;
+import pro.sky.animalsheltertelegrambot.repository.PhotoRepository;
+import pro.sky.animalsheltertelegrambot.service.PetService;
 import pro.sky.animalsheltertelegrambot.service.PhotoService;
+import pro.sky.animalsheltertelegrambot.service.ReportService;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static pro.sky.animalsheltertelegrambot.utils.MethodNameRetriever.getMethodName;
 
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PhotoServiceImpl implements PhotoService {
+    private final PhotoRepository photoRepository;
+    private final PetService petService;
+    private final ReportService reportService;
 
+    @Value("${photos.dir.path}")
+    private String photosDir;
+
+    @Value("${photos.extensions}")
+    private String extensions;
 
     @Override
-    public Photo addPhoto(Photo photo) {
-        return null;
+    public void addPhotosForPet(Long petId, MultipartFile[] photos) throws IOException {
+        logWhenMethodInvoked(getMethodName());
+        validatePhotos(photos);
+        int start = findIndexOfLastPhoto(photoRepository.findLastFilePathByPetId(petId).orElse(null));
+
+        for (MultipartFile photoFile : photos) {
+            if (++start == 10) {
+                throw new LimitOfPhotosException();
+            }
+            Pet pet = petService.getPet(petId);
+            Path filePath = Path.of(photosDir, "number=" + start + "petId=" + petId + "." +
+                    getExtension(photoFile.getOriginalFilename()));
+            Files.createDirectories(filePath.getParent());
+            Files.deleteIfExists(filePath);
+            try (
+                    InputStream is = photoFile.getInputStream();
+                    OutputStream os = Files.newOutputStream(filePath, CREATE_NEW);
+                    BufferedInputStream bis = new BufferedInputStream(is, 1024);
+                    BufferedOutputStream bos = new BufferedOutputStream(os, 1024)
+            ) {
+                bis.transferTo(bos);
+            }
+            log.debug("Filling avatar object with values and saving in repository");
+            Photo photo = new Photo();
+            photo.setPet(pet);
+            photo.setFilePath(filePath.toString());
+            photo.setFileSize(photoFile.getSize());
+            photo.setMediaType(photoFile.getContentType());
+            photoRepository.save(photo);
+        }
     }
 
     @Override
-    public Photo getPhoto(Long id) {
-        return null;
+    public void addPhotosForReport(Long reportId, MultipartFile[] photos) throws IOException {
+        logWhenMethodInvoked(getMethodName());
+        validatePhotos(photos);
+        int start = findIndexOfLastPhoto(photoRepository.findLastFilePathByReportId(reportId).orElse(null));
+
+        for (MultipartFile photoFile : photos) {
+            if (++start == 10) {
+                throw new LimitOfPhotosException();
+            }
+            Report report = reportService.getReport(reportId);
+            Path filePath = Path.of(photosDir, "number=" + start + "reportId=" + reportId + "." +
+                    getExtension(photoFile.getOriginalFilename()));
+            Files.createDirectories(filePath.getParent());
+            Files.deleteIfExists(filePath);
+            try (
+                    InputStream is = photoFile.getInputStream();
+                    OutputStream os = Files.newOutputStream(filePath, CREATE_NEW);
+                    BufferedInputStream bis = new BufferedInputStream(is, 1024);
+                    BufferedOutputStream bos = new BufferedOutputStream(os, 1024)
+            ) {
+                bis.transferTo(bos);
+            }
+            log.debug("Filling avatar object with values and saving in repository");
+            Photo photo = new Photo();
+            photo.setReport(report);
+            photo.setFilePath(filePath.toString());
+            photo.setFileSize(photoFile.getSize());
+            photo.setMediaType(photoFile.getContentType());
+            photoRepository.save(photo);
+        }
     }
 
     @Override
-    public Photo updatePhoto(Long id, Photo photo) {
-        return null;
+    public void getPhotosByPetId(Long petId, Long photoNumber, HttpServletResponse response) throws IOException {
+        logWhenMethodInvoked(getMethodName());
+        List<Photo> photos = findPhotosByPetId(petId);
+        Photo photo = photos.stream()
+                .filter(e -> e.getFilePath().contains("number=" + photoNumber))
+                .findAny()
+                .orElseThrow(() -> new PhotoNotFoundException());
+        try (
+                InputStream is = Files.newInputStream(Path.of(photo.getFilePath()));
+                BufferedInputStream bis = new BufferedInputStream(is, 1024);
+                BufferedOutputStream bos = new BufferedOutputStream(response.getOutputStream(), 1024)
+        ) {
+            response.setContentType(photo.getMediaType());
+            response.setContentLength(photo.getFileSize().intValue());
+            bis.transferTo(bos);
+        }
+        response.setStatus(HttpServletResponse.SC_OK);
     }
 
     @Override
-    public void deletePhoto(Long id) {
+    public void getPhotosByReportId(Long reportId, Long photoNumber, HttpServletResponse response) throws IOException {
+        logWhenMethodInvoked(getMethodName());
+        List<Photo> photos = findPhotosByReportId(reportId);
+        Photo photo = photos.stream()
+                .filter(e -> e.getFilePath().contains("number=" + photoNumber))
+                .findAny()
+                .orElseThrow(() -> new PhotoNotFoundException());
+        try (
+                InputStream is = Files.newInputStream(Path.of(photo.getFilePath()));
+                BufferedInputStream bis = new BufferedInputStream(is, 1024);
+                BufferedOutputStream bos = new BufferedOutputStream(response.getOutputStream(), 1024)
+        ) {
+            response.setContentType(photo.getMediaType());
+            response.setContentLength(photo.getFileSize().intValue());
+            response.setStatus(HttpServletResponse.SC_OK);
+            bis.transferTo(bos);
+        }
+    }
 
+    @Override
+    public void deletePhotosByPetId(Long petId) {
+        List<Photo> byPetId = photoRepository.findByPetId(petId);
+        for (Photo photo : byPetId) {
+            photoRepository.delete(photo);
+        }
+    }
+
+    @Override
+    public void deletePhotosByReportId(Long reportId) {
+        List<Photo> byReportId = photoRepository.findByReportId(reportId);
+        for (Photo photo : byReportId) {
+            photoRepository.delete(photo);
+        }
+    }
+
+    /**
+     * Метод по поиску хранимых фотографий, относящихся к определенному питомцу
+     *
+     * @param petId id питомца, фотографии которого требуется найти
+     * @return List сущностей Photo
+     * @throws PhotoNotFoundException в случае отсутствия фотографий
+     */
+    private List<Photo> findPhotosByPetId(Long petId) {
+        List<Photo> byPetId = photoRepository.findByPetId(petId);
+        if (byPetId.isEmpty()) {
+            throw new PhotoNotFoundException();
+        }
+        return byPetId;
+    }
+
+    /**
+     * Метод по поиску хранимых фотографий, относящихся к определенному отчету
+     *
+     * @param reportId id отчета, фотографии которого требуется найти
+     * @return List сущностей Photo
+     * @throws PhotoNotFoundException в случае отсутствия фотографий
+     */
+    private List<Photo> findPhotosByReportId(Long reportId) {
+        List<Photo> byReportId = photoRepository.findByReportId(reportId);
+        if (byReportId.isEmpty()) {
+            throw new PhotoNotFoundException();
+        }
+        return byReportId;
+    }
+
+    /**
+     * Вспомогательный метод, который позволяет вычленить расширение из имени файла
+     *
+     * @param fileName файл, расширение которого нужно получить
+     * @return строка, которая представляет расширение переданного файла
+     */
+    private String getExtension(String fileName) {
+        return fileName.substring(fileName.lastIndexOf(".") + 1);
+    }
+
+    /**
+     * Вспомогательный метод, который валидирует переданные пользователем файлы.
+     * Выбрасывает исключение, если одно из условий срабатывает.
+     *
+     * @param photos набор файлов, которые нужно проверить
+     * @throws PhotoIsEmptyException      если один из файлов не был отправлен
+     * @throws BadPhotoExtensionException если один из файлов недопустимого расширения
+     */
+    private void validatePhotos(MultipartFile[] photos) {
+        logWhenMethodInvoked(getMethodName());
+        for (MultipartFile photo : photos) {
+            if (photo == null) {
+                throw new PhotoIsEmptyException();
+            }
+            if (!(extensions.contains(getExtension(photo.getOriginalFilename())))) {
+                throw new BadPhotoExtensionException();
+            }
+        }
+    }
+
+    /**
+     * Поиск и возврат порядкового номера последней фотографии.
+     * В случае, если полученный список пуст, это значит, что фотографий еще не было добавлено.
+     * Следовательно, возвращаем первый номер - 0.
+     *
+     * @param filePath путь последней добавленной фотографии для питомца/отчета
+     * @return номер текущей по счету фотографии или 0, если список пуст
+     * @throws LimitOfPhotosException если превышен лимит по количеству фотографий
+     */
+    private int findIndexOfLastPhoto(String filePath) {
+        logWhenMethodInvoked(getMethodName());
+        if (filePath == null) {
+            return 0;
+        } else {
+            int curValue = Integer.parseInt(Character.toString(filePath.charAt(filePath.indexOf("=") + 1)));
+            if (curValue == 9) {
+                throw new LimitOfPhotosException();
+            }
+            return curValue;
+        }
+    }
+
+    private void logWhenMethodInvoked(String methodName) {
+        log.info("Method '{}'", methodName);
     }
 }

--- a/src/main/java/pro/sky/animalsheltertelegrambot/utils/GlobalExceptionHandler.java
+++ b/src/main/java/pro/sky/animalsheltertelegrambot/utils/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package pro.sky.animalsheltertelegrambot.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+/**
+ * Класс, который отлавливает прописанные в нем типы исключений и выполняет логику по их обработке.
+ */
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<String> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        log.warn("MaxUploadSizeExceededException occurred");
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,7 @@ spring.datasource.username=telegram_user
 spring.datasource.password=123
 spring.liquibase.change-log=classpath:liquibase/changelog-master.yml
 server.error.include-message=always
+spring.jpa.hibernate.ddl-auto=update
+photos.dir.path=./photos
+photos.extensions=jpg, jpeg, png, ico, gif, tiff, eps, svg, bmp
+servlet.file.max-file-size=3MB


### PR DESCRIPTION
1) Добавление логики в сервис Photo. Пользователь API может добавлять сразу несколько фотографий, которые относятся либо к отчету, либо к питомцу. Но получать фото по GET запросу может только по одной штуке за раз. Для этого нужно ввести id питомца(отчета) и порядковый номер желаемой фотографии;
2) Связывание таблиц Pet с Photo и Report с Photo;
3) Обработка исключения при превышении максимально допустимого размера файла (3 MB) прописана в GlobalExceptionHandler;
4) Сущность (питомец/отчет) может иметь максимум 9 связанных с ней фотографий (при превышении выбрасывается LimitOfPhotosException). Данное ограничение связано с особенностью хранения фотографий.